### PR TITLE
Fix: Gate Non-core Tests for Nightly CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,20 +36,11 @@ Zygote = "0.6, 0.7"
 julia = "1.10, 1.11"
 
 [extras]
-AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
 SatelliteToolboxTransformations = "6b019ec1-7a1e-4f04-96c7-a9db1ca5514d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "DelimitedFiles", "DifferentiationInterface", "FiniteDiff", "ForwardDiff", "LinearAlgebra", "Pkg", "PolyesterForwardDiff", "SatelliteToolboxTransformations", "Zygote"]
+test = ["Test", "DelimitedFiles", "LinearAlgebra", "Pkg", "SatelliteToolboxTransformations"]

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -3,6 +3,10 @@
 # Tests related to performance and memory allocations.
 #
 ############################################################################################
+@testset "Aqua.jl" begin
+    Aqua.test_all(SatelliteToolboxGravityModels; ambiguities=(recursive = false), deps_compat=(check_extras = false))
+end
+
 @testset "JET Testing" begin
     rep = JET.test_package(SatelliteToolboxGravityModels; toplevel_logger=nothing, target_modules=(@__MODULE__,))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,47 +8,6 @@ using LinearAlgebra
 using SatelliteToolboxTransformations
 using Scratch
 
-using DifferentiationInterface
-using FiniteDiff, ForwardDiff, PolyesterForwardDiff, Zygote
-
-if isempty(VERSION.prerelease)
-    # Add Mooncake and Enzyme to the project if not the nightly version
-    # Adding them via the Project.toml isn't working because it tries to compile them before reaching the gating
-    using Pkg
-    Pkg.add("Mooncake")
-    Pkg.add("Enzyme")
-    Pkg.add("JET")
-    Pkg.add("AllocCheck")
-
-    # Test with Mooncake and Enzyme along with the other backends
-    using Mooncake, Enzyme
-    const _BACKENDS = (
-        ("ForwardDiff", AutoForwardDiff()),
-        ("Enzyme", AutoEnzyme()),
-        ("Mooncake", AutoMooncake(;config=nothing)),
-        ("PolyesterForwardDiff", AutoPolyesterForwardDiff()),
-        ("Zygote", AutoZygote()),
-    )
-
-    using JET
-    using AllocCheck
-
-    @testset "Performance and Memory Allocations" verbose = true begin
-        include("./allocations.jl")
-    end
-else
-    @warn "Mooncake.jl and Enzyme.jl not guaranteed to work on julia-nightly, skipping tests"
-    const _BACKENDS = (
-        ("ForwardDiff", AutoForwardDiff()),
-        ("PolyesterForwardDiff", AutoPolyesterForwardDiff()),
-        ("Zygote", AutoZygote()),
-    )
-
-    @warn "JET and AllocCheck not guaranteed to work on julia-nightly, skipping tests"
-end
-
-using Aqua
-
 # We must clear the scratch space before the tests to avoid errors.
 clear_scratchspaces!(SatelliteToolboxGravityModels)
 
@@ -60,11 +19,45 @@ end
     include("./gravity_models.jl")
 end
 
-@testset "Differentiation Tests" verbose = true begin
-    include("differentiability.jl")
-end
 
-@testset "Aqua.jl" begin
-    Aqua.test_all(SatelliteToolboxGravityModels; ambiguities=(recursive = false), deps_compat=(check_extras = false))
-end
+if isempty(VERSION.prerelease)
+    # Add Mooncake and Enzyme to the project if not the nightly version
+    # Adding them via the Project.toml isn't working because it tries to compile them before reaching the gating
+    using Pkg
+    Pkg.add("DifferentiationInterface")
+    Pkg.add("Enzyme")
+    Pkg.add("FiniteDiff")
+    Pkg.add("ForwardDiff")
+    Pkg.add("Mooncake")
+    Pkg.add("PolyesterForwardDiff")
+    Pkg.add("Zygote")
 
+    Pkg.add("JET")
+    Pkg.add("AllocCheck")
+    Pkg.add("Aqua")
+
+    # Test with Mooncake and Enzyme along with the other backends
+    using DifferentiationInterface
+    using Enzyme, FiniteDiff, ForwardDiff, Mooncake, PolyesterForwardDiff, Zygote
+    const _BACKENDS = (
+        ("ForwardDiff", AutoForwardDiff()),
+        ("Enzyme", AutoEnzyme()),
+        ("Mooncake", AutoMooncake(;config=nothing)),
+        ("PolyesterForwardDiff", AutoPolyesterForwardDiff()),
+        ("Zygote", AutoZygote()),
+    )
+
+    using JET
+    using AllocCheck
+    using Aqua
+
+    @testset "Performance and Memory Allocations" verbose = true begin
+        include("./allocations.jl")
+    end
+    @testset "Differentiation Tests" verbose = true begin
+        include("differentiability.jl")
+    end
+else
+    @warn "Differentiation backends not guaranteed to work on julia-nightly, skipping tests"
+    @warn "Performance checks not guaranteed to work on julia-nightly, skipping tests"
+end


### PR DESCRIPTION
I don't think we can guarantee these packages will work with the nightly CI, so gating of differentiation and performance tests to not cause issues